### PR TITLE
Update RegExodus dependency (gwt.xml change).

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,11 +3,11 @@ org.gradle.jvmargs=-Xms128m -Xmx512m -Dfile.encoding=UTF-8 -Dconsole.encoding=UT
 org.gradle.configureondemand=false
 
 gdxVersion=1.11.0
-regExodusVersion=0.1.13
+regExodusVersion=0.1.15
 
 GROUP=com.rafaskoberg.gdx
 POM_ARTIFACT_ID=typing-label
-VERSION_NAME=1.3.0
+VERSION_NAME=1.3.1-SNAPSHOT
 
 POM_NAME=typing-label
 POM_DESCRIPTION=A libGDX Label that appears as if it was being typed in real time.

--- a/src/main/resources/com/rafaskoberg/gdx/typinglabel/typinglabel.gwt.xml
+++ b/src/main/resources/com/rafaskoberg/gdx/typinglabel/typinglabel.gwt.xml
@@ -9,14 +9,14 @@
      You will also need to add a dependency on RegExodus in your GWT project (it might be useful to have in core, but it
      isn't at all necessary). The Gradle dependencies for GWT are:
      
-     api "com.github.tommyettinger:regexodus:0.1.12"
-     api "com.github.tommyettinger:regexodus:0.1.12:sources"
+     api "com.github.tommyettinger:regexodus:0.1.15"
+     api "com.github.tommyettinger:regexodus:0.1.15:sources"
      
      If you want it in core as well,  you can move the first line to core's dependencies, but keep the second in GWT.
   -->
 <module>
     <source path=""/>
     <inherits name="com.badlogic.gdx.backends.gdx_backends_gwt" />
-    <inherits name="regexodus"/>
+    <inherits name="regexodus.regexodus"/>
     <extend-configuration-property name="gdx.reflect.include" value="com.rafaskoberg.gdx.typinglabel"/>
 </module>


### PR DESCRIPTION
This one is important for gdx-liftoff, which tries to pick the most recent version for any dependency (0.1.15 for RegExodus). That most recent RegExodus uses a different `inherits` line in its .gwt.xml file, because I discovered with many of my libraries that using the root folder (`regexodus`) causes problems that are fixed by using a subfolder (`regexodus.regexodus`). I don't know exactly what the nature of the root-folder problem was, other than it affected user projects, I probably had too many libraries all using the root folder, and they conflicted in some way. Using subfolders seems to fix this, but that means changing the RegExodus dependency (and if using GWT, the inherits line, in user projects :( ).