### PR TITLE
Fix for #28 (parentAlpha sometimes being ignored).

### DIFF
--- a/src/main/java/com/rafaskoberg/gdx/typinglabel/TypingLabel.java
+++ b/src/main/java/com/rafaskoberg/gdx/typinglabel/TypingLabel.java
@@ -885,12 +885,16 @@ public class TypingLabel extends Label {
         // Here we store color as its components, to avoid producing garbage and to allow modifying the local color.
         float r = color.r, g = color.g, b = color.b, a = color.a;
         for(TypingGlyph glyph : glyphCache) {
-            if(glyph.internalIndex >= 0 && glyph.color != null) {
-                // Unless we want to use a packed float, it's easiest to pass a Color object here, multiplying this
-                // Label color (as its components) by the color of the individual glyph.
-                bitmapFontCache.setColors(
-                        color.set(glyph.color).mul(r, g, b, a),
-                        glyph.internalIndex, glyph.internalIndex + 1);
+            if (glyph.internalIndex >= 0) {
+                if (glyph.color != null) {
+                    // Unless we want to use a packed float, it's easiest to pass a Color object here, multiplying this
+                    // Label color (as its components) by the color of the individual glyph.
+                    bitmapFontCache.setColors(
+                            Color.toFloatBits(r * glyph.color.r, g * glyph.color.g, b * glyph.color.b, a * glyph.color.a),
+                            glyph.internalIndex, glyph.internalIndex + 1);
+                } else if(a < 1f) {
+                    bitmapFontCache.setColors(color, glyph.internalIndex, glyph.internalIndex + 1);
+                }
             }
         }
 

--- a/src/test/java/com/rafaskoberg/gdx/typinglabel/TypingLabelTest.java
+++ b/src/test/java/com/rafaskoberg/gdx/typinglabel/TypingLabelTest.java
@@ -25,6 +25,7 @@ public class TypingLabelTest extends ApplicationAdapter {
     Skin        skin;
     Stage       stage;
     SpriteBatch batch;
+    Table       table;
     TypingLabel label;
     TypingLabel labelEvent;
     TextButton  buttonPause;
@@ -48,7 +49,7 @@ public class TypingLabelTest extends ApplicationAdapter {
         Gdx.input.setInputProcessor(stage);
 
         // Create root table
-        final Table table = new Table();
+        table = new Table();
         stage.addActor(table);
         table.setFillParent(true);
 
@@ -162,8 +163,11 @@ public class TypingLabelTest extends ApplicationAdapter {
         // Create label
         final TypingLabel label = new TypingLabel(text, skin);
 
-        // Set default token
-        String defaultToken = "{EASE}{FADE=0;1;0.33}";
+        // Set default token; this line only eases in glyphs with movement...
+        String defaultToken = "{EASE}";
+        // While this line eases them in with movement and transparency.
+//        String defaultToken = "{EASE}{FADE=0;1;0.33}";
+
         defaultToken = defaultToken.replace('{', cOpen).replace('}', cClose);
         label.setDefaultToken(defaultToken);
 
@@ -209,6 +213,8 @@ public class TypingLabelTest extends ApplicationAdapter {
 
     public void update(float delta) {
         stage.act(delta);
+        // TODO: This is only here to debug Issue #28 . It is related to the default token omitting FADE.
+//        table.getColor().a = 0.2f;
     }
 
     @Override


### PR DESCRIPTION
The bug was relatively simple; if glyph.color was null, then its color wouldn't be set, including its alpha. Now we just check for alpha being less than 1 if glyph.color is null, and use our already-configured tint color in that case without needing to use glyph.color. The only tricky part is that I needed to avoid modifying color so it could be used when glyph.color is null... So setColors is given a packed float color assembled from color and glyph.color channels, and is otherwise the same. You may want to adjust the test; right now it's one commented line (with a TODO) away from showing the fix.